### PR TITLE
Add cross-platform building with Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "build-*-*/*"
-        tag: ${{ github.sha }}
+        tag: ${{ github.run_id }}
         commit: "main"
         body: "Automated release of ${{ github.sha }}"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "build-*-*/*"
-        tag: "latest"
+        tag: ${{ github.sha }}
         commit: "main"
         body: "Automated release of ${{ github.sha }}"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
+      exclude:
+      # Don't build ARM/Windows:
+      - os: windows
+        arch: arm64
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [x86_64 arm64]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build executable
+      run: go build -o build/
+      env:
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
+
+  publish:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    steps:
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "build/*"
+        body: "Automated release of ${{ github.sha }}"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v2
     - name: Debug
-    - run: ls -R
+      run: ls -R
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "build/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
       env:
         GOOS: ${{ matrix.os }}
         GOARCH: ${{ matrix.arch }}
+    - name: Upload executable
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-${{ matrix.os }}-${{ matrix.arch }}
+        path: build/*
 
   publish:
     runs-on: ubuntu-latest
@@ -37,6 +42,9 @@ jobs:
     needs: build
 
     steps:
+    - uses: actions/download-artifact@v2
+    - name: Debug
+    - run: ls -R
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "build/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, windows]
-        arch: [x86_64 arm64]
+        arch: [x86_64, arm64]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "build/*"
+        tag: "latest"
+        commit: "main"
         body: "Automated release of ${{ github.sha }}"
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin, windows]
-        arch: [x86_64, arm64]
+        arch: [amd64, arm64]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
-      exclude:
-      # Don't build ARM/Windows:
-      - os: windows
-        arch: arm64
+        exclude:
+        # Don't build ARM/Windows:
+        - os: windows
+          arch: arm64
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Build executable
-      run: go build -o build/
+      run: go build -o astro-demo-${{ matrix.os }}-${{ matrix.arch }}
       env:
         GOOS: ${{ matrix.os }}
         GOARCH: ${{ matrix.arch }}
@@ -34,7 +34,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: build-${{ matrix.os }}-${{ matrix.arch }}
-        path: build/*
+        path: astro-demo-${{ matrix.os }}-${{ matrix.arch }}
 
   publish:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
       run: ls -R
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "build/*"
+        artifacts: "build-*-*/*"
         tag: "latest"
         commit: "main"
         body: "Automated release of ${{ github.sha }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Determine Go version from go.mod
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
     - name: Build executable
       run: go build -o build/
       env:


### PR DESCRIPTION
Adds an Action with a matrix that builds the app for multiple OS/architecture combinations.

Each job stores the executable as a build artefact, and then the final publishing step creates a release and attaches all the artefacts. 